### PR TITLE
feat: Add private configuration protection for public repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,3 +59,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --keep-vars

--- a/PRIVATE_CONFIG.md
+++ b/PRIVATE_CONFIG.md
@@ -1,19 +1,19 @@
-# Приватная конфигурация для продакшена
+# Private Configuration for Production
 
-## ⚠️ ВАЖНО: Публичный репозиторий
+## ⚠️ IMPORTANT: Public Repository
 
-Поскольку этот репозиторий публичный, **НЕ добавляйте приватные токены в `wrangler.toml`**!
+Since this is a public repository, **DO NOT add private tokens to `wrangler.toml`**!
 
-## 🔒 Как настроить приватный конфиг
+## 🔒 How to Configure Private Config
 
-### Способ 1: Через Cloudflare Dashboard (РЕКОМЕНДУЕТСЯ)
+### Method 1: Via Cloudflare Dashboard (RECOMMENDED)
 
-1. **Откройте Cloudflare Dashboard:**
-   - Перейдите в: `Workers & Pages` → `ai-worker-proxy` → `Settings` → `Variables`
+1. **Open Cloudflare Dashboard:**
+   - Navigate to: `Workers & Pages` → `ai-worker-proxy` → `Settings` → `Variables`
 
-2. **Добавьте Environment Variables:**
+2. **Add Environment Variables:**
 
-   **Переменная: `ROUTES_CONFIG`**
+   **Variable: `ROUTES_CONFIG`**
    ```json
    {
      "your-model": [
@@ -33,61 +33,61 @@
    }
    ```
 
-   **Переменная: `PROXY_AUTH_TOKEN`**
+   **Variable: `PROXY_AUTH_TOKEN`**
    ```
    your-real-secret-token
    ```
 
-3. **Добавьте Secrets (API ключи):**
-   - Нажмите "Add variable" → выберите "Encrypt"
-   - Добавьте все ваши API ключи:
+3. **Add Secrets (API keys):**
+   - Click "Add variable" → select "Encrypt"
+   - Add all your API keys:
      - `ANTHROPIC_KEY_1` = `sk-ant-xxxxx`
      - `GOOGLE_KEY_1` = `AIzaxxxxx`
      - `OPENAI_KEY_1` = `sk-xxxxx`
-     - и т.д.
+     - etc.
 
-4. **Сохраните и деплойте:**
-   - Нажмите "Save and Deploy"
-   - Или просто сохраните - GitHub Actions не перезапишет эти переменные благодаря флагу `--keep-vars`
+4. **Save and Deploy:**
+   - Click "Save and Deploy"
+   - Or just save - GitHub Actions won't overwrite these variables thanks to the `--keep-vars` flag
 
 ---
 
-### Способ 2: Через Wrangler CLI (локально)
+### Method 2: Via Wrangler CLI (locally)
 
 ```bash
-# Добавить Environment Variables
+# Add Environment Variables
 wrangler secret put ANTHROPIC_KEY_1
 wrangler secret put GOOGLE_KEY_1
 wrangler secret put PROXY_AUTH_TOKEN
 
-# Установить ROUTES_CONFIG через dashboard или:
-# Создать отдельный wrangler.production.toml (НЕ коммитить!)
+# Set ROUTES_CONFIG via dashboard or:
+# Create a separate wrangler.production.toml (DO NOT commit!)
 ```
 
 ---
 
-### Способ 3: Cloudflare KV Storage (продвинутый)
+### Method 3: Cloudflare KV Storage (advanced)
 
-Если хотите изменять конфиг без редеплоя:
+If you want to modify config without redeploying:
 
-1. **Создайте KV namespace:**
+1. **Create KV namespace:**
    ```bash
    wrangler kv:namespace create "CONFIG"
    ```
 
-2. **Добавьте в wrangler.toml:**
+2. **Add to wrangler.toml:**
    ```toml
    [[kv_namespaces]]
    binding = "CONFIG"
    id = "your-kv-id"
    ```
 
-3. **Загрузите конфиг в KV:**
+3. **Upload config to KV:**
    ```bash
    wrangler kv:key put --namespace-id=xxx "ROUTES_CONFIG" @config.json
    ```
 
-4. **Измените код для чтения из KV:**
+4. **Modify code to read from KV:**
    ```typescript
    // src/router.ts
    const configStr = await env.CONFIG.get("ROUTES_CONFIG") || env.ROUTES_CONFIG;
@@ -95,9 +95,9 @@ wrangler secret put PROXY_AUTH_TOKEN
 
 ---
 
-## 🚀 GitHub Actions и приватный конфиг
+## 🚀 GitHub Actions and Private Config
 
-GitHub Actions **НЕ перезапишет** ваш приватный конфиг благодаря флагу `--keep-vars`:
+GitHub Actions **WILL NOT overwrite** your private config thanks to the `--keep-vars` flag:
 
 ```yaml
 # .github/workflows/deploy.yml
@@ -106,46 +106,46 @@ GitHub Actions **НЕ перезапишет** ваш приватный кон�
   with:
     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-    command: deploy --keep-vars  # <-- Сохраняет переменные из дашборда
+    command: deploy --keep-vars  # <-- Preserves variables from dashboard
 ```
 
-### Что происходит при деплое:
+### What happens during deployment:
 
-- ✅ **Обновляется:** Код (TypeScript файлы)
-- ✅ **Обновляется:** Зависимости (package.json)
-- ❌ **НЕ обновляется:** Environment Variables из дашборда
-- ❌ **НЕ обновляется:** Secrets
-
----
-
-## 📋 Чеклист настройки
-
-- [ ] Добавлены все Environment Variables в Cloudflare Dashboard
-- [ ] Добавлены все Secrets (API ключи)
-- [ ] Проверено что `ROUTES_CONFIG` содержит ваши приватные роуты
-- [ ] `wrangler.toml` в репо содержит только пример
-- [ ] GitHub Actions имеет флаг `--keep-vars`
-- [ ] Протестирован деплой - приватный конфиг не перезаписывается
+- ✅ **Updated:** Code (TypeScript files)
+- ✅ **Updated:** Dependencies (package.json)
+- ❌ **NOT updated:** Environment Variables from dashboard
+- ❌ **NOT updated:** Secrets
 
 ---
 
-## 🔍 Проверка конфигурации
+## 📋 Setup Checklist
 
-После деплоя проверьте что используется ваш приватный конфиг:
+- [ ] All Environment Variables added to Cloudflare Dashboard
+- [ ] All Secrets (API keys) added
+- [ ] Verified that `ROUTES_CONFIG` contains your private routes
+- [ ] `wrangler.toml` in repo contains example only
+- [ ] GitHub Actions has `--keep-vars` flag
+- [ ] Tested deployment - private config is not overwritten
+
+---
+
+## 🔍 Configuration Verification
+
+After deployment, verify that your private config is being used:
 
 ```bash
-# Проверить переменные
+# Check variables
 wrangler tail
 
-# Или сделайте тестовый запрос
+# Or make a test request
 curl https://your-worker.workers.dev/health
 ```
 
 ---
 
-## ⚙️ Локальная разработка
+## ⚙️ Local Development
 
-Для локальной разработки создайте `.dev.vars` (не коммитится):
+For local development, create `.dev.vars` (not committed):
 
 ```bash
 # .dev.vars
@@ -156,7 +156,7 @@ GOOGLE_KEY_1=AIzaxxxxx
 ROUTES_CONFIG={"test": [{"provider": "anthropic", "model": "claude-opus-4", "apiKeys": ["ANTHROPIC_KEY_1"]}]}
 ```
 
-Затем:
+Then:
 ```bash
 npm run dev
 ```
@@ -165,27 +165,27 @@ npm run dev
 
 ## 🆘 Troubleshooting
 
-### Конфиг перезаписывается при деплое
+### Config gets overwritten on deploy
 
-**Проблема:** GitHub Actions перезаписывает ваш приватный конфиг
+**Problem:** GitHub Actions overwrites your private config
 
-**Решение:**
-1. Проверьте что в `.github/workflows/deploy.yml` есть `command: deploy --keep-vars`
-2. Если нет - добавьте и закоммитьте
-3. Пересоздайте Environment Variables в дашборде
+**Solution:**
+1. Check that `.github/workflows/deploy.yml` has `command: deploy --keep-vars`
+2. If not - add it and commit
+3. Recreate Environment Variables in dashboard
 
-### Переменные не читаются
+### Variables are not being read
 
-**Проблема:** Worker не видит переменные из дашборда
+**Problem:** Worker doesn't see variables from dashboard
 
-**Решение:**
-1. Убедитесь что переменные добавлены именно в Environment Variables (не в Secrets для vars)
-2. Secrets используйте только для API ключей
-3. После изменения переменных в дашборде нажмите "Save and Deploy"
+**Solution:**
+1. Make sure variables are added to Environment Variables (not in Secrets for vars)
+2. Use Secrets only for API keys
+3. After changing variables in dashboard, click "Save and Deploy"
 
 ---
 
-## 📖 Дополнительно
+## 📖 Additional Resources
 
 - [Cloudflare Environment Variables](https://developers.cloudflare.com/workers/configuration/environment-variables/)
 - [Wrangler Secrets](https://developers.cloudflare.com/workers/wrangler/commands/#secret)

--- a/PRIVATE_CONFIG.md
+++ b/PRIVATE_CONFIG.md
@@ -1,0 +1,192 @@
+# Приватная конфигурация для продакшена
+
+## ⚠️ ВАЖНО: Публичный репозиторий
+
+Поскольку этот репозиторий публичный, **НЕ добавляйте приватные токены в `wrangler.toml`**!
+
+## 🔒 Как настроить приватный конфиг
+
+### Способ 1: Через Cloudflare Dashboard (РЕКОМЕНДУЕТСЯ)
+
+1. **Откройте Cloudflare Dashboard:**
+   - Перейдите в: `Workers & Pages` → `ai-worker-proxy` → `Settings` → `Variables`
+
+2. **Добавьте Environment Variables:**
+
+   **Переменная: `ROUTES_CONFIG`**
+   ```json
+   {
+     "your-model": [
+       {
+         "provider": "anthropic",
+         "model": "claude-opus-4-20250514",
+         "apiKeys": ["ANTHROPIC_KEY_1"]
+       }
+     ],
+     "fast": [
+       {
+         "provider": "google",
+         "model": "gemini-2.0-flash-exp",
+         "apiKeys": ["GOOGLE_KEY_1"]
+       }
+     ]
+   }
+   ```
+
+   **Переменная: `PROXY_AUTH_TOKEN`**
+   ```
+   your-real-secret-token
+   ```
+
+3. **Добавьте Secrets (API ключи):**
+   - Нажмите "Add variable" → выберите "Encrypt"
+   - Добавьте все ваши API ключи:
+     - `ANTHROPIC_KEY_1` = `sk-ant-xxxxx`
+     - `GOOGLE_KEY_1` = `AIzaxxxxx`
+     - `OPENAI_KEY_1` = `sk-xxxxx`
+     - и т.д.
+
+4. **Сохраните и деплойте:**
+   - Нажмите "Save and Deploy"
+   - Или просто сохраните - GitHub Actions не перезапишет эти переменные благодаря флагу `--keep-vars`
+
+---
+
+### Способ 2: Через Wrangler CLI (локально)
+
+```bash
+# Добавить Environment Variables
+wrangler secret put ANTHROPIC_KEY_1
+wrangler secret put GOOGLE_KEY_1
+wrangler secret put PROXY_AUTH_TOKEN
+
+# Установить ROUTES_CONFIG через dashboard или:
+# Создать отдельный wrangler.production.toml (НЕ коммитить!)
+```
+
+---
+
+### Способ 3: Cloudflare KV Storage (продвинутый)
+
+Если хотите изменять конфиг без редеплоя:
+
+1. **Создайте KV namespace:**
+   ```bash
+   wrangler kv:namespace create "CONFIG"
+   ```
+
+2. **Добавьте в wrangler.toml:**
+   ```toml
+   [[kv_namespaces]]
+   binding = "CONFIG"
+   id = "your-kv-id"
+   ```
+
+3. **Загрузите конфиг в KV:**
+   ```bash
+   wrangler kv:key put --namespace-id=xxx "ROUTES_CONFIG" @config.json
+   ```
+
+4. **Измените код для чтения из KV:**
+   ```typescript
+   // src/router.ts
+   const configStr = await env.CONFIG.get("ROUTES_CONFIG") || env.ROUTES_CONFIG;
+   ```
+
+---
+
+## 🚀 GitHub Actions и приватный конфиг
+
+GitHub Actions **НЕ перезапишет** ваш приватный конфиг благодаря флагу `--keep-vars`:
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Deploy to Cloudflare Workers
+  uses: cloudflare/wrangler-action@v3
+  with:
+    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    command: deploy --keep-vars  # <-- Сохраняет переменные из дашборда
+```
+
+### Что происходит при деплое:
+
+- ✅ **Обновляется:** Код (TypeScript файлы)
+- ✅ **Обновляется:** Зависимости (package.json)
+- ❌ **НЕ обновляется:** Environment Variables из дашборда
+- ❌ **НЕ обновляется:** Secrets
+
+---
+
+## 📋 Чеклист настройки
+
+- [ ] Добавлены все Environment Variables в Cloudflare Dashboard
+- [ ] Добавлены все Secrets (API ключи)
+- [ ] Проверено что `ROUTES_CONFIG` содержит ваши приватные роуты
+- [ ] `wrangler.toml` в репо содержит только пример
+- [ ] GitHub Actions имеет флаг `--keep-vars`
+- [ ] Протестирован деплой - приватный конфиг не перезаписывается
+
+---
+
+## 🔍 Проверка конфигурации
+
+После деплоя проверьте что используется ваш приватный конфиг:
+
+```bash
+# Проверить переменные
+wrangler tail
+
+# Или сделайте тестовый запрос
+curl https://your-worker.workers.dev/health
+```
+
+---
+
+## ⚙️ Локальная разработка
+
+Для локальной разработки создайте `.dev.vars` (не коммитится):
+
+```bash
+# .dev.vars
+PROXY_AUTH_TOKEN=local-dev-token
+ANTHROPIC_KEY_1=sk-ant-xxxxx
+GOOGLE_KEY_1=AIzaxxxxx
+
+ROUTES_CONFIG={"test": [{"provider": "anthropic", "model": "claude-opus-4", "apiKeys": ["ANTHROPIC_KEY_1"]}]}
+```
+
+Затем:
+```bash
+npm run dev
+```
+
+---
+
+## 🆘 Troubleshooting
+
+### Конфиг перезаписывается при деплое
+
+**Проблема:** GitHub Actions перезаписывает ваш приватный конфиг
+
+**Решение:**
+1. Проверьте что в `.github/workflows/deploy.yml` есть `command: deploy --keep-vars`
+2. Если нет - добавьте и закоммитьте
+3. Пересоздайте Environment Variables в дашборде
+
+### Переменные не читаются
+
+**Проблема:** Worker не видит переменные из дашборда
+
+**Решение:**
+1. Убедитесь что переменные добавлены именно в Environment Variables (не в Secrets для vars)
+2. Secrets используйте только для API ключей
+3. После изменения переменных в дашборде нажмите "Save and Deploy"
+
+---
+
+## 📖 Дополнительно
+
+- [Cloudflare Environment Variables](https://developers.cloudflare.com/workers/configuration/environment-variables/)
+- [Wrangler Secrets](https://developers.cloudflare.com/workers/wrangler/commands/#secret)
+- [KV Storage](https://developers.cloudflare.com/kv/)

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ npm run dev
 
 ## Configuration
 
+### ⚠️ Public Repository - Private Config
+
+**IMPORTANT**: This is a public repository. **DO NOT** commit your private API keys or production configuration to `wrangler.toml`!
+
+For production/private configuration:
+- 📖 **See [PRIVATE_CONFIG.md](PRIVATE_CONFIG.md)** for detailed instructions
+- 🔒 Set environment variables in **Cloudflare Dashboard** → Settings → Variables
+- ✅ GitHub Actions uses `--keep-vars` flag to preserve your dashboard config
+- 🚫 The `wrangler.toml` file contains **example configuration only**
+
 ### Model Routing Configuration
 
 Each model name maps to an array of provider configurations. The proxy will try providers in order until one succeeds.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,12 +6,27 @@ compatibility_date = "2024-01-01"
 [ai]
 binding = "AI"
 
+# ====================================================================================
+# IMPORTANT: This is a PUBLIC example configuration for the repository
+# ====================================================================================
+# For PRODUCTION/PRIVATE use:
+# 1. Set environment variables in Cloudflare Dashboard:
+#    Workers & Pages → your-worker → Settings → Variables
+# 2. Add ROUTES_CONFIG and PROXY_AUTH_TOKEN there
+# 3. GitHub Actions uses --keep-vars flag to preserve your dashboard config
+#
+# The configuration below is used for:
+# - Local development (wrangler dev)
+# - As an example for users
+# - Will NOT override your dashboard settings when deployed from GitHub Actions
+# ====================================================================================
+
 [vars]
-# Proxy authentication token (can be overridden with secret)
+# Proxy authentication token (EXAMPLE - set real token in Cloudflare Dashboard)
 PROXY_AUTH_TOKEN = "your-secret-proxy-token-here"
 
-# Model routing configuration (JSON format)
-# Each model name maps to an array of providers with fallback support
+# Model routing configuration - EXAMPLE ONLY
+# Configure your real routes in Cloudflare Dashboard → Settings → Variables
 ROUTES_CONFIG = '''
 {
   "deep-think": [


### PR DESCRIPTION
- Add --keep-vars flag to GitHub Actions deploy Prevents overwriting environment variables from Cloudflare Dashboard

- Update wrangler.toml with clear warnings Mark configuration as EXAMPLE ONLY Add extensive comments about private config

- Create PRIVATE_CONFIG.md guide Step-by-step instructions for Cloudflare Dashboard setup Multiple methods: Dashboard, CLI, KV Storage Troubleshooting section

- Update README.md Add warning about public repository Link to private config documentation

This allows:
✅ Public repository with example code
✅ Private production config in Cloudflare Dashboard ✅ GitHub Actions deploys code without overwriting config ✅ Users can customize via Dashboard UI without code changes