### PR TITLE
fix: Remove [vars] from wrangler.toml to prevent config overwrite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,4 +59,3 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --keep-vars

--- a/PRIVATE_CONFIG.md
+++ b/PRIVATE_CONFIG.md
@@ -97,17 +97,21 @@ If you want to modify config without redeploying:
 
 ## 🚀 GitHub Actions and Private Config
 
-GitHub Actions **WILL NOT overwrite** your private config thanks to the `--keep-vars` flag:
+GitHub Actions **WILL NOT overwrite** your private config because `wrangler.toml` has **NO [vars] section**:
 
-```yaml
-# .github/workflows/deploy.yml
-- name: Deploy to Cloudflare Workers
-  uses: cloudflare/wrangler-action@v3
-  with:
-    apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-    accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-    command: deploy --keep-vars  # <-- Preserves variables from dashboard
+```toml
+# wrangler.toml
+name = "ai-worker-proxy"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[ai]
+binding = "AI"
+
+# No [vars] section - all configuration via Dashboard or .dev.vars
 ```
+
+This ensures your Cloudflare Dashboard variables are **never** overwritten during deployment.
 
 ### What happens during deployment:
 
@@ -170,9 +174,9 @@ npm run dev
 **Problem:** GitHub Actions overwrites your private config
 
 **Solution:**
-1. Check that `.github/workflows/deploy.yml` has `command: deploy --keep-vars`
-2. If not - add it and commit
-3. Recreate Environment Variables in dashboard
+1. Make sure `wrangler.toml` has **NO [vars] section**
+2. All configuration should be in Cloudflare Dashboard only
+3. For local dev, use `.dev.vars` file (not committed)
 
 ### Variables are not being read
 

--- a/README.md
+++ b/README.md
@@ -36,49 +36,52 @@ npm install
 
 ### 2. Configure Model Routing
 
-Edit `wrangler.toml` to configure your model names and providers:
+**For Production (Cloudflare Dashboard):**
 
-```toml
-[vars]
-PROXY_AUTH_TOKEN = "your-secret-proxy-token-here"
+1. Go to: `Cloudflare Dashboard` → `Workers & Pages` → `ai-worker-proxy` → `Settings` → `Variables`
+2. Add Environment Variable `ROUTES_CONFIG`:
+   ```json
+   {
+     "deep-think": [
+       {
+         "provider": "anthropic",
+         "model": "claude-opus-4-20250514",
+         "apiKeys": ["ANTHROPIC_KEY_1"]
+       }
+     ],
+     "fast": [
+       {
+         "provider": "google",
+         "model": "gemini-2.0-flash-exp",
+         "apiKeys": ["GOOGLE_KEY_1"]
+       }
+     ]
+   }
+   ```
+3. See `wrangler.example.toml` for more configuration examples
 
-ROUTES_CONFIG = '''
-{
-  "deep-think": [
-    {
-      "provider": "anthropic",
-      "model": "claude-opus-4-20250514",
-      "apiKeys": ["ANTHROPIC_KEY_1", "ANTHROPIC_KEY_2"]
-    },
-    {
-      "provider": "google",
-      "model": "gemini-2.0-flash-thinking-exp-01-21",
-      "apiKeys": ["GOOGLE_KEY_1"]
-    }
-  ],
-  "fast": [
-    {
-      "provider": "google",
-      "model": "gemini-2.0-flash-exp",
-      "apiKeys": ["GOOGLE_KEY_1"]
-    }
-  ]
-}
-'''
-```
+**For Local Development:**
+
+Create `.dev.vars` file (see `.dev.vars.example` for format)
 
 **Note**: Model names (e.g., `"deep-think"`, `"fast"`) are used in your API requests, not URL paths.
 
-### 3. Set API Keys
+### 3. Set API Keys and Auth Token
+
+**Via Cloudflare Dashboard (Recommended):**
+
+1. Go to: `Workers & Pages` → `ai-worker-proxy` → `Settings` → `Variables`
+2. Click "Add variable" → Select "Encrypt" for secrets:
+   - `ANTHROPIC_KEY_1` = `sk-ant-xxxxx`
+   - `GOOGLE_KEY_1` = `AIzaxxxxx`
+   - `OPENAI_KEY_1` = `sk-xxxxx`
+   - `PROXY_AUTH_TOKEN` = `your-secret-token`
+
+**Or via Wrangler CLI:**
 
 ```bash
-# Set your API keys as secrets
 wrangler secret put ANTHROPIC_KEY_1
 wrangler secret put GOOGLE_KEY_1
-wrangler secret put OPENAI_KEY_1
-# ... add more as needed
-
-# Optional: Override proxy auth token
 wrangler secret put PROXY_AUTH_TOKEN
 ```
 
@@ -101,8 +104,8 @@ npm run dev
 For production/private configuration:
 - 📖 **See [PRIVATE_CONFIG.md](PRIVATE_CONFIG.md)** for detailed instructions
 - 🔒 Set environment variables in **Cloudflare Dashboard** → Settings → Variables
-- ✅ GitHub Actions uses `--keep-vars` flag to preserve your dashboard config
-- 🚫 The `wrangler.toml` file contains **example configuration only**
+- ✅ The `wrangler.toml` file has **NO [vars] section** to prevent overwriting your config
+- 📋 See `wrangler.example.toml` for configuration examples
 
 ### Model Routing Configuration
 

--- a/wrangler.example.toml
+++ b/wrangler.example.toml
@@ -1,0 +1,88 @@
+name = "ai-worker-proxy"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+# Cloudflare AI binding (optional)
+[ai]
+binding = "AI"
+
+# ====================================================================================
+# EXAMPLE CONFIGURATION - DO NOT USE IN PRODUCTION
+# ====================================================================================
+# This file shows the configuration format.
+# Copy relevant parts to Cloudflare Dashboard for production use.
+#
+# For production:
+# - Cloudflare Dashboard → Workers & Pages → ai-worker-proxy → Settings → Variables
+# - Add ROUTES_CONFIG and PROXY_AUTH_TOKEN as Environment Variables
+# - Add API keys as Encrypted variables (Secrets)
+#
+# For local development:
+# - Create .dev.vars file (see .dev.vars.example)
+# ====================================================================================
+
+[vars]
+# Proxy authentication token
+PROXY_AUTH_TOKEN = "your-secret-proxy-token-here"
+
+# Model routing configuration
+ROUTES_CONFIG = '''
+{
+  "deep-think": [
+    {
+      "provider": "anthropic",
+      "model": "claude-opus-4-20250514",
+      "apiKeys": ["ANTHROPIC_KEY_1", "ANTHROPIC_KEY_2"]
+    },
+    {
+      "provider": "google",
+      "model": "gemini-2.0-flash-thinking-exp-01-21",
+      "apiKeys": ["GOOGLE_KEY_1"]
+    }
+  ],
+  "fast": [
+    {
+      "provider": "google",
+      "model": "gemini-2.0-flash-exp",
+      "apiKeys": ["GOOGLE_KEY_1"]
+    },
+    {
+      "provider": "cloudflare-ai",
+      "model": "@cf/meta/llama-3.1-8b-instruct",
+      "apiKeys": []
+    }
+  ],
+  "nvidia": [
+    {
+      "provider": "openai-compatible",
+      "baseUrl": "https://integrate.api.nvidia.com/v1",
+      "model": "nvidia/llama-3.1-nemotron-70b-instruct",
+      "apiKeys": ["NVIDIA_KEY_1", "NVIDIA_KEY_2"]
+    }
+  ],
+  "openai": [
+    {
+      "provider": "openai",
+      "model": "gpt-4o",
+      "apiKeys": ["OPENAI_KEY_1"]
+    }
+  ],
+  "groq": [
+    {
+      "provider": "openai-compatible",
+      "baseUrl": "https://api.groq.com/openai/v1",
+      "model": "llama-3.3-70b-versatile",
+      "apiKeys": ["GROQ_KEY_1"]
+    }
+  ]
+}
+'''
+
+# API Keys (add these as Secrets in Cloudflare Dashboard):
+# - ANTHROPIC_KEY_1
+# - ANTHROPIC_KEY_2
+# - GOOGLE_KEY_1
+# - NVIDIA_KEY_1
+# - NVIDIA_KEY_2
+# - OPENAI_KEY_1
+# - GROQ_KEY_1

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,75 +7,21 @@ compatibility_date = "2024-01-01"
 binding = "AI"
 
 # ====================================================================================
-# IMPORTANT: This is a PUBLIC example configuration for the repository
+# IMPORTANT: Environment Variables Configuration
 # ====================================================================================
-# For PRODUCTION/PRIVATE use:
-# 1. Set environment variables in Cloudflare Dashboard:
-#    Workers & Pages → your-worker → Settings → Variables
-# 2. Add ROUTES_CONFIG and PROXY_AUTH_TOKEN there
-# 3. GitHub Actions uses --keep-vars flag to preserve your dashboard config
+# This file does NOT contain [vars] section to prevent overwriting your
+# private configuration in Cloudflare Dashboard.
 #
-# The configuration below is used for:
-# - Local development (wrangler dev)
-# - As an example for users
-# - Will NOT override your dashboard settings when deployed from GitHub Actions
+# For PRODUCTION configuration:
+# - Set all variables in Cloudflare Dashboard: Workers & Pages → Settings → Variables
+# - See wrangler.example.toml for configuration format
+# - See PRIVATE_CONFIG.md for detailed setup instructions
+#
+# For LOCAL DEVELOPMENT:
+# - Create .dev.vars file (not committed to git)
+# - See .dev.vars.example for format
+# - Run: npm run dev
 # ====================================================================================
 
-[vars]
-# Proxy authentication token (EXAMPLE - set real token in Cloudflare Dashboard)
-PROXY_AUTH_TOKEN = "your-secret-proxy-token-here"
+# No [vars] section here - all configuration via Dashboard or .dev.vars
 
-# Model routing configuration - EXAMPLE ONLY
-# Configure your real routes in Cloudflare Dashboard → Settings → Variables
-ROUTES_CONFIG = '''
-{
-  "deep-think": [
-    {
-      "provider": "anthropic",
-      "model": "claude-opus-4-20250514",
-      "apiKeys": ["ANTHROPIC_KEY_1", "ANTHROPIC_KEY_2"]
-    },
-    {
-      "provider": "google",
-      "model": "gemini-2.0-flash-thinking-exp-01-21",
-      "apiKeys": ["GOOGLE_KEY_1"]
-    }
-  ],
-  "fast": [
-    {
-      "provider": "google",
-      "model": "gemini-2.0-flash-exp",
-      "apiKeys": ["GOOGLE_KEY_1"]
-    },
-    {
-      "provider": "cloudflare-ai",
-      "model": "@cf/meta/llama-3.1-8b-instruct",
-      "apiKeys": []
-    }
-  ],
-  "nvidia": [
-    {
-      "provider": "openai-compatible",
-      "baseUrl": "https://integrate.api.nvidia.com/v1",
-      "model": "nvidia/llama-3.1-nemotron-70b-instruct",
-      "apiKeys": ["NVIDIA_KEY_1", "NVIDIA_KEY_2"]
-    }
-  ],
-  "openai": [
-    {
-      "provider": "openai",
-      "model": "gpt-4o",
-      "apiKeys": ["OPENAI_KEY_1"]
-    }
-  ]
-}
-'''
-
-# Secrets (set these with: wrangler secret put <KEY_NAME>)
-# - ANTHROPIC_KEY_1
-# - ANTHROPIC_KEY_2
-# - GOOGLE_KEY_1
-# - NVIDIA_KEY_1
-# - NVIDIA_KEY_2
-# - OPENAI_KEY_1
-# - PROXY_AUTH_TOKEN (optional override)


### PR DESCRIPTION
BREAKING CHANGE: wrangler.toml no longer contains [vars] section

The previous approach with --keep-vars flag did NOT work. wrangler.toml with [vars] section ALWAYS overwrites Dashboard variables.

Changes:
- Remove [vars] section from wrangler.toml completely
- Create wrangler.example.toml with example configuration
- Remove --keep-vars flag from GitHub Actions (not needed)
- Update all documentation to reflect new approach

How it works now:
✅ wrangler.toml has NO [vars] - cannot overwrite anything ✅ Production config ONLY in Cloudflare Dashboard
✅ Local dev uses .dev.vars file
✅ GitHub Actions deploys code, variables untouched

This is the ONLY way to prevent config overwriting in public repos.

Updated files:
- wrangler.toml: removed [vars] section
- wrangler.example.toml: created with examples
- .github/workflows/deploy.yml: removed --keep-vars
- README.md: updated Quick Start instructions
- PRIVATE_CONFIG.md: corrected explanation