### PR TITLE
fix: Use GitHub Variables/Secrets for config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,12 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Add ROUTES_CONFIG to wrangler.toml
+      - name: Replace ROUTES_CONFIG in wrangler.toml
         run: |
+          # Remove existing [vars] section and everything after it
+          sed -i '/^\[vars\]/,$d' wrangler.toml
+
+          # Add new [vars] section with GitHub Variable
           cat >> wrangler.toml << 'EOF'
 
           [vars]
@@ -67,17 +71,3 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          secrets: |
-            PROXY_AUTH_TOKEN
-            ANTHROPIC_KEY_1
-            GOOGLE_KEY_1
-            OPENAI_KEY_1
-            NVIDIA_KEY_1
-            GROQ_KEY_1
-        env:
-          PROXY_AUTH_TOKEN: ${{ secrets.PROXY_AUTH_TOKEN }}
-          ANTHROPIC_KEY_1: ${{ secrets.ANTHROPIC_KEY_1 }}
-          GOOGLE_KEY_1: ${{ secrets.GOOGLE_KEY_1 }}
-          OPENAI_KEY_1: ${{ secrets.OPENAI_KEY_1 }}
-          NVIDIA_KEY_1: ${{ secrets.NVIDIA_KEY_1 }}
-          GROQ_KEY_1: ${{ secrets.GROQ_KEY_1 }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,30 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Add ROUTES_CONFIG to wrangler.toml
+        run: |
+          cat >> wrangler.toml << 'EOF'
+
+          [vars]
+          ROUTES_CONFIG = '''${{ vars.ROUTES_CONFIG }}'''
+          EOF
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          secrets: |
+            PROXY_AUTH_TOKEN
+            ANTHROPIC_KEY_1
+            GOOGLE_KEY_1
+            OPENAI_KEY_1
+            NVIDIA_KEY_1
+            GROQ_KEY_1
+        env:
+          PROXY_AUTH_TOKEN: ${{ secrets.PROXY_AUTH_TOKEN }}
+          ANTHROPIC_KEY_1: ${{ secrets.ANTHROPIC_KEY_1 }}
+          GOOGLE_KEY_1: ${{ secrets.GOOGLE_KEY_1 }}
+          OPENAI_KEY_1: ${{ secrets.OPENAI_KEY_1 }}
+          NVIDIA_KEY_1: ${{ secrets.NVIDIA_KEY_1 }}
+          GROQ_KEY_1: ${{ secrets.GROQ_KEY_1 }}

--- a/PRIVATE_CONFIG.md
+++ b/PRIVATE_CONFIG.md
@@ -2,31 +2,50 @@
 
 ## 🎯 How It Works
 
-- **`ROUTES_CONFIG`** → GitHub Variable (not secret) → deployed as Cloudflare env var
-- **`PROXY_AUTH_TOKEN`** + API keys → GitHub Secrets → deployed as Cloudflare secrets
+- **`ROUTES_CONFIG`** → GitHub Variable → injected into wrangler.toml during deploy
+- **Secrets** (PROXY_AUTH_TOKEN, API keys) → Cloudflare Dashboard (manually, persist across deploys)
 
-This setup ensures:
-- ✅ `ROUTES_CONFIG` can be easily updated without re-entering secrets
-- ✅ Sensitive tokens remain encrypted as secrets
-- ✅ No config in wrangler.toml (stays public-safe)
+**Key point:** Cloudflare Secrets are NEVER deleted by wrangler deploy. Set them once in Dashboard, they stay forever.
 
 ---
 
 ## 📝 Setup Instructions
 
-### Step 1: Add GitHub Variable
+### Step 1: Add Secrets to Cloudflare Dashboard
+
+1. Go to **Cloudflare Dashboard** → **Workers & Pages** → **ai-worker-proxy** → **Settings** → **Variables**
+
+2. Click **"Add variable"** → Select **"Encrypt"** (this makes it a Secret)
+
+3. Add these secrets:
+   - `PROXY_AUTH_TOKEN` = `your-secret-token`
+   - `ANTHROPIC_KEY_1` = `sk-ant-xxxxx`
+   - `GOOGLE_KEY_1` = `AIzaxxxxx`
+   - `OPENAI_KEY_1` = `sk-xxxxx`
+   - `NVIDIA_KEY_1` = `nvapi-xxxxx`
+   - `GROQ_KEY_1` = `gsk_xxxxx`
+   - etc.
+
+4. Click **"Save and Deploy"**
+
+**IMPORTANT:** These secrets will NEVER be deleted or overwritten by GitHub Actions deployments. Set them once and forget.
+
+### Step 2: Add GitHub Variable
 
 1. Go to your repo → **Settings** → **Secrets and variables** → **Actions** → **Variables** tab
+
 2. Click **"New repository variable"**
+
 3. Name: `ROUTES_CONFIG`
-4. Value (JSON, can be multiline):
+
+4. Value (JSON, can be formatted):
 ```json
 {
   "deep-think": [
     {
       "provider": "anthropic",
       "model": "claude-opus-4-20250514",
-      "apiKeys": ["ANTHROPIC_KEY_1"]
+      "apiKeys": ["ANTHROPIC_KEY_1", "ANTHROPIC_KEY_2"]
     }
   ],
   "fast": [
@@ -35,38 +54,36 @@ This setup ensures:
       "model": "gemini-2.0-flash-exp",
       "apiKeys": ["GOOGLE_KEY_1"]
     }
+  ],
+  "nvidia": [
+    {
+      "provider": "openai-compatible",
+      "baseUrl": "https://integrate.api.nvidia.com/v1",
+      "model": "nvidia/llama-3.1-nemotron-70b-instruct",
+      "apiKeys": ["NVIDIA_KEY_1"]
+    }
   ]
 }
 ```
 
-### Step 2: Add GitHub Secrets
+### Step 3: Add GitHub Secrets (for Cloudflare auth)
 
 1. Go to **Secrets** tab (next to Variables)
-2. Click **"New repository secret"**
-3. Add these secrets:
 
-**Required:**
-- `CLOUDFLARE_API_TOKEN` - Your Cloudflare API token
-- `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare account ID
-- `PROXY_AUTH_TOKEN` - Your proxy authentication token
+2. Add these:
+   - `CLOUDFLARE_API_TOKEN` - Your Cloudflare API token
+   - `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare account ID
 
-**API Keys (as needed):**
-- `ANTHROPIC_KEY_1` = `sk-ant-xxxxx`
-- `GOOGLE_KEY_1` = `AIzaxxxxx`
-- `OPENAI_KEY_1` = `sk-xxxxx`
-- `NVIDIA_KEY_1` = `nvapi-xxxxx`
-- `GROQ_KEY_1` = `gsk_xxxxx`
-
-### Step 3: Push to Main
+### Step 4: Deploy
 
 ```bash
 git push origin main
 ```
 
 GitHub Actions will:
-1. Add `ROUTES_CONFIG` to wrangler.toml temporarily
-2. Deploy code + ROUTES_CONFIG as env var
-3. Set secrets using `wrangler secret put`
+1. Replace `ROUTES_CONFIG` in wrangler.toml with your GitHub Variable
+2. Deploy to Cloudflare
+3. Your Dashboard secrets remain untouched
 
 ---
 
@@ -74,15 +91,16 @@ GitHub Actions will:
 
 ### Update Routes (ROUTES_CONFIG)
 
-1. Edit the variable in GitHub: Settings → Secrets and variables → Actions → Variables → ROUTES_CONFIG
-2. Push any commit to main (or re-run the workflow)
+1. Edit the variable in GitHub: Settings → Secrets and variables → Actions → **Variables** → ROUTES_CONFIG
+2. Push any commit to main (or manually re-run workflow)
 3. Done! New routes deployed.
 
 ### Update Secrets (API Keys, Auth Token)
 
-1. Edit the secret in GitHub: Settings → Secrets and variables → Actions → Secrets
-2. Push any commit to main (or re-run the workflow)
-3. Done! Secrets updated.
+1. Go to **Cloudflare Dashboard** → Workers & Pages → ai-worker-proxy → Settings → Variables
+2. Edit the encrypted variable
+3. Click "Save and Deploy"
+4. Done! (No need to push anything)
 
 ---
 
@@ -104,6 +122,8 @@ Run locally:
 npm run dev
 ```
 
+Wrangler will automatically load variables from `.dev.vars`.
+
 ---
 
 ## 🆘 Troubleshooting
@@ -111,34 +131,41 @@ npm run dev
 ### GitHub Actions fails with "vars.ROUTES_CONFIG not found"
 
 **Solution:**
-1. Make sure you added ROUTES_CONFIG as a **Variable** (not Secret)
+1. Make sure you added `ROUTES_CONFIG` as a **Variable** (not Secret)
 2. Go to Settings → Secrets and variables → Actions → **Variables** tab
-3. Variables and Secrets are different tabs!
+3. Variables and Secrets are in different tabs!
 
-### Worker returns "Invalid ROUTES_CONFIG"
+### Worker can't authenticate / missing API keys
 
 **Solution:**
-1. Check ROUTES_CONFIG is valid JSON
-2. Make sure all API keys referenced in ROUTES_CONFIG are added as Secrets
-3. Check GitHub Actions logs to see what was deployed
+1. Check secrets are set in **Cloudflare Dashboard** (not GitHub)
+2. Go to Cloudflare Dashboard → Workers & Pages → ai-worker-proxy → Settings → Variables
+3. Make sure secrets are marked as "Encrypted"
+4. Click "Save and Deploy" after adding/editing
+
+### ROUTES_CONFIG is not updating after push
+
+**Solution:**
+1. Check GitHub Actions logs - did the workflow run?
+2. Check if GitHub Variable `ROUTES_CONFIG` is set correctly
+3. Make sure the JSON is valid (use a JSON validator)
+4. Check the workflow replaced the [vars] section (look at logs)
 
 ### Want to add a new API provider
 
 **Solution:**
-1. Add the API key to GitHub Secrets (e.g., `DEEPSEEK_KEY_1`)
-2. Update `.github/workflows/deploy.yml` to include it in `secrets:` list and `env:` section
-3. Update `ROUTES_CONFIG` variable with the new route
-4. Push to deploy
+1. Add the API key to **Cloudflare Dashboard** as encrypted variable (e.g., `DEEPSEEK_KEY_1`)
+2. Update GitHub Variable `ROUTES_CONFIG` to include the new route
+3. Push to trigger deployment
 
 ---
 
 ## 📋 Checklist
 
-- [ ] `ROUTES_CONFIG` added as GitHub **Variable** (not Secret)
+- [ ] All secrets added to **Cloudflare Dashboard** (encrypted variables)
+- [ ] `ROUTES_CONFIG` added as **GitHub Variable**
 - [ ] `CLOUDFLARE_API_TOKEN` added as GitHub Secret
 - [ ] `CLOUDFLARE_ACCOUNT_ID` added as GitHub Secret
-- [ ] `PROXY_AUTH_TOKEN` added as GitHub Secret
-- [ ] All API keys added as GitHub Secrets
 - [ ] `.dev.vars` created for local development (not committed)
 - [ ] Pushed to main and verified deployment succeeded
 
@@ -146,23 +173,24 @@ npm run dev
 
 ## 📖 Why This Works
 
-**Before deployment**, GitHub Actions injects ROUTES_CONFIG into wrangler.toml:
-```toml
-[vars]
-ROUTES_CONFIG = '''{ your routes }'''
-```
+**The Problem:**
+- Wrangler ALWAYS overwrites vars defined in wrangler.toml [vars] section
+- But Cloudflare Secrets are NEVER deleted by wrangler deploy
 
-This file is only used during deployment and never committed to git.
+**The Solution:**
+- `ROUTES_CONFIG` goes in [vars] → GitHub Actions replaces it before deploy
+- Sensitive data (tokens, API keys) goes in Cloudflare Secrets → never touched
 
-**Secrets** are uploaded using `wrangler secret put`, which:
-- Encrypts them in Cloudflare
-- Persists them across deployments
-- Never gets overwritten
+**Result:**
+- Public repo stays clean (example config only)
+- ROUTES_CONFIG easily updated via GitHub Variable
+- Secrets stay secure in Cloudflare Dashboard
+- No accidental overwrites
 
-**Result:** Clean separation between public code and private config.
+---
 
 ## 📚 References
 
+- [Cloudflare Secrets Documentation](https://developers.cloudflare.com/workers/configuration/secrets/)
 - [GitHub Actions Variables](https://docs.github.com/en/actions/learn-github-actions/variables)
-- [GitHub Actions Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
-- [Cloudflare Secrets](https://developers.cloudflare.com/workers/wrangler/commands/#secret)
+- [Wrangler Configuration](https://developers.cloudflare.com/workers/wrangler/configuration/)

--- a/README.md
+++ b/README.md
@@ -34,12 +34,11 @@ cd AI-Worker-Proxy
 npm install
 ```
 
-### 2. Configure Model Routing
+### 2. Configure via GitHub
 
-**For Production (Cloudflare Dashboard):**
-
-1. Go to: `Cloudflare Dashboard` → `Workers & Pages` → `ai-worker-proxy` → `Settings` → `Variables`
-2. Add Environment Variable `ROUTES_CONFIG`:
+**Add GitHub Variable:**
+1. Go to your repo → Settings → Secrets and variables → Actions → **Variables** tab
+2. Add `ROUTES_CONFIG`:
    ```json
    {
      "deep-think": [
@@ -58,54 +57,37 @@ npm install
      ]
    }
    ```
-3. See `wrangler.toml` for more configuration examples
+
+**Add GitHub Secrets:**
+1. Go to **Secrets** tab
+2. Add:
+   - `CLOUDFLARE_API_TOKEN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+   - `PROXY_AUTH_TOKEN`
+   - `ANTHROPIC_KEY_1`, `GOOGLE_KEY_1`, etc.
 
 **For Local Development:**
-
 Create `.dev.vars` file (see `.dev.vars.example` for format)
 
-**Note**: Model names (e.g., `"deep-think"`, `"fast"`) are used in your API requests, not URL paths.
-
-### 3. Set API Keys and Auth Token
-
-**Via Cloudflare Dashboard (Recommended):**
-
-1. Go to: `Workers & Pages` → `ai-worker-proxy` → `Settings` → `Variables`
-2. Click "Add variable" → Select "Encrypt" for secrets:
-   - `ANTHROPIC_KEY_1` = `sk-ant-xxxxx`
-   - `GOOGLE_KEY_1` = `AIzaxxxxx`
-   - `OPENAI_KEY_1` = `sk-xxxxx`
-   - `PROXY_AUTH_TOKEN` = `your-secret-token`
-
-**Or via Wrangler CLI:**
+### 3. Deploy
 
 ```bash
-wrangler secret put ANTHROPIC_KEY_1
-wrangler secret put GOOGLE_KEY_1
-wrangler secret put PROXY_AUTH_TOKEN
+git push origin main
 ```
 
-### 4. Deploy
-
-```bash
-# Deploy to Cloudflare Workers
-npm run deploy
-
-# Or run locally for development
-npm run dev
-```
+GitHub Actions will deploy automatically.
 
 ## Configuration
 
 ### ⚠️ Public Repository - Private Config
 
-**IMPORTANT**: This is a public repository. **DO NOT** commit your private API keys or production configuration to `wrangler.toml`!
+**IMPORTANT**: This is a public repository. **DO NOT** commit your private API keys or production configuration!
 
 For production/private configuration:
 - 📖 **See [PRIVATE_CONFIG.md](PRIVATE_CONFIG.md)** for detailed instructions
-- 🔒 Set environment variables in **Cloudflare Dashboard** → Settings → Variables
-- ✅ The `wrangler.toml` has `keep_vars = true` to prevent overwriting your Dashboard config
-- 📋 Example configuration is in `wrangler.toml` [vars] section (for reference only)
+- 🔧 `ROUTES_CONFIG` → GitHub Variable (easy to update, not encrypted)
+- 🔒 `PROXY_AUTH_TOKEN` + API keys → GitHub Secrets (encrypted)
+- ✅ No secrets in wrangler.toml - everything via GitHub Actions
 
 ### Model Routing Configuration
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,20 @@ cd AI-Worker-Proxy
 npm install
 ```
 
-### 2. Configure via GitHub
+### 2. Configure Secrets (Cloudflare Dashboard)
+
+**Add secrets to Cloudflare Dashboard:**
+1. Go to **Cloudflare Dashboard** → **Workers & Pages** → **ai-worker-proxy** → **Settings** → **Variables**
+2. Click "Add variable" → Select **"Encrypt"**
+3. Add:
+   - `PROXY_AUTH_TOKEN` = your auth token
+   - `ANTHROPIC_KEY_1` = sk-ant-xxxxx
+   - `GOOGLE_KEY_1` = AIzaxxxxx
+   - etc.
+
+**IMPORTANT:** These secrets persist across deployments and are never overwritten.
+
+### 3. Configure Routes (GitHub Variable)
 
 **Add GitHub Variable:**
 1. Go to your repo → Settings → Secrets and variables → Actions → **Variables** tab
@@ -58,18 +71,16 @@ npm install
    }
    ```
 
-**Add GitHub Secrets:**
+**Add GitHub Secrets (for Cloudflare auth):**
 1. Go to **Secrets** tab
 2. Add:
    - `CLOUDFLARE_API_TOKEN`
    - `CLOUDFLARE_ACCOUNT_ID`
-   - `PROXY_AUTH_TOKEN`
-   - `ANTHROPIC_KEY_1`, `GOOGLE_KEY_1`, etc.
 
 **For Local Development:**
 Create `.dev.vars` file (see `.dev.vars.example` for format)
 
-### 3. Deploy
+### 4. Deploy
 
 ```bash
 git push origin main
@@ -85,9 +96,9 @@ GitHub Actions will deploy automatically.
 
 For production/private configuration:
 - 📖 **See [PRIVATE_CONFIG.md](PRIVATE_CONFIG.md)** for detailed instructions
-- 🔧 `ROUTES_CONFIG` → GitHub Variable (easy to update, not encrypted)
-- 🔒 `PROXY_AUTH_TOKEN` + API keys → GitHub Secrets (encrypted)
-- ✅ No secrets in wrangler.toml - everything via GitHub Actions
+- 🔧 `ROUTES_CONFIG` → GitHub Variable (replaced in wrangler.toml during deploy)
+- 🔒 Secrets (PROXY_AUTH_TOKEN, API keys) → Cloudflare Dashboard (persist forever, never overwritten)
+- ✅ wrangler.toml contains example config only
 
 ### Model Routing Configuration
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,9 +84,9 @@ export interface RouteConfig {
 // Environment bindings
 export interface Env {
   AI?: any; // Cloudflare AI binding
-  PROXY_AUTH_TOKEN: string;
-  ROUTES_CONFIG: string;
-  [key: string]: any; // Dynamic API keys
+  PROXY_AUTH_TOKEN: string; // Cloudflare Secret (set in Dashboard)
+  ROUTES_CONFIG: string; // Environment variable (injected from GitHub Variable)
+  [key: string]: any; // Dynamic API keys (Cloudflare Secrets, set in Dashboard)
 }
 
 // Provider response

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,83 +2,21 @@ name = "ai-worker-proxy"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
-# IMPORTANT: Preserve environment variables set in Cloudflare Dashboard
-# This prevents wrangler from overwriting your production config during deployment
-keep_vars = true
-
 # Cloudflare AI binding (optional)
 [ai]
 binding = "AI"
 
 # ====================================================================================
-# EXAMPLE CONFIGURATION
+# IMPORTANT: No [vars] section here!
 # ====================================================================================
-# For PRODUCTION: Set your real values in Cloudflare Dashboard
-# For LOCAL DEV: Create .dev.vars file (see .dev.vars.example)
+# Having [vars] section WILL OVERWRITE your Cloudflare Dashboard variables.
+# Even with keep_vars=true, variables defined in [vars] will be overwritten.
+#
+# For PRODUCTION: Set variables in Cloudflare Dashboard
+#   Dashboard → Workers & Pages → ai-worker-proxy → Settings → Variables
+#
+# For LOCAL DEV: Create .dev.vars file
+#   See .dev.vars.example for format
+#
+# For EXAMPLES: See wrangler.toml.example
 # ====================================================================================
-
-[vars]
-# Proxy authentication token
-PROXY_AUTH_TOKEN = "your-secret-proxy-token-here"
-
-# Model routing configuration
-ROUTES_CONFIG = '''
-{
-  "deep-think": [
-    {
-      "provider": "anthropic",
-      "model": "claude-opus-4-20250514",
-      "apiKeys": ["ANTHROPIC_KEY_1", "ANTHROPIC_KEY_2"]
-    },
-    {
-      "provider": "google",
-      "model": "gemini-2.0-flash-thinking-exp-01-21",
-      "apiKeys": ["GOOGLE_KEY_1"]
-    }
-  ],
-  "fast": [
-    {
-      "provider": "google",
-      "model": "gemini-2.0-flash-exp",
-      "apiKeys": ["GOOGLE_KEY_1"]
-    },
-    {
-      "provider": "cloudflare-ai",
-      "model": "@cf/meta/llama-3.1-8b-instruct",
-      "apiKeys": []
-    }
-  ],
-  "nvidia": [
-    {
-      "provider": "openai-compatible",
-      "baseUrl": "https://integrate.api.nvidia.com/v1",
-      "model": "nvidia/llama-3.1-nemotron-70b-instruct",
-      "apiKeys": ["NVIDIA_KEY_1", "NVIDIA_KEY_2"]
-    }
-  ],
-  "openai": [
-    {
-      "provider": "openai",
-      "model": "gpt-4o",
-      "apiKeys": ["OPENAI_KEY_1"]
-    }
-  ],
-  "groq": [
-    {
-      "provider": "openai-compatible",
-      "baseUrl": "https://api.groq.com/openai/v1",
-      "model": "llama-3.3-70b-versatile",
-      "apiKeys": ["GROQ_KEY_1"]
-    }
-  ]
-}
-'''
-
-# API Keys (add these as Secrets in Cloudflare Dashboard):
-# - ANTHROPIC_KEY_1
-# - ANTHROPIC_KEY_2
-# - GOOGLE_KEY_1
-# - NVIDIA_KEY_1
-# - NVIDIA_KEY_2
-# - OPENAI_KEY_1
-# - GROQ_KEY_1

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,16 +7,45 @@ compatibility_date = "2024-01-01"
 binding = "AI"
 
 # ====================================================================================
-# IMPORTANT: No [vars] section here!
+# EXAMPLE CONFIGURATION
 # ====================================================================================
-# Having [vars] section WILL OVERWRITE your Cloudflare Dashboard variables.
-# Even with keep_vars=true, variables defined in [vars] will be overwritten.
-#
-# For PRODUCTION: Set variables in Cloudflare Dashboard
-#   Dashboard → Workers & Pages → ai-worker-proxy → Settings → Variables
-#
-# For LOCAL DEV: Create .dev.vars file
-#   See .dev.vars.example for format
-#
-# For EXAMPLES: See wrangler.toml.example
+# This [vars] section contains example configuration.
+# GitHub Actions will REPLACE it with real ROUTES_CONFIG from GitHub Variable.
+# Secrets (PROXY_AUTH_TOKEN, API keys) are set in Cloudflare Dashboard manually.
 # ====================================================================================
+
+[vars]
+# Model routing configuration (example - will be replaced by GitHub Actions)
+ROUTES_CONFIG = '''
+{
+  "deep-think": [
+    {
+      "provider": "anthropic",
+      "model": "claude-opus-4-20250514",
+      "apiKeys": ["ANTHROPIC_KEY_1", "ANTHROPIC_KEY_2"]
+    }
+  ],
+  "fast": [
+    {
+      "provider": "google",
+      "model": "gemini-2.0-flash-exp",
+      "apiKeys": ["GOOGLE_KEY_1"]
+    }
+  ],
+  "nvidia": [
+    {
+      "provider": "openai-compatible",
+      "baseUrl": "https://integrate.api.nvidia.com/v1",
+      "model": "nvidia/llama-3.1-nemotron-70b-instruct",
+      "apiKeys": ["NVIDIA_KEY_1"]
+    }
+  ]
+}
+'''
+
+# Secrets to set in Cloudflare Dashboard:
+# - PROXY_AUTH_TOKEN
+# - ANTHROPIC_KEY_1, ANTHROPIC_KEY_2
+# - GOOGLE_KEY_1
+# - NVIDIA_KEY_1
+# - OPENAI_KEY_1, GROQ_KEY_1, etc.


### PR DESCRIPTION
ROUTES_CONFIG → GitHub Variable (injected to wrangler.toml during deploy)
PROXY_AUTH_TOKEN + API keys → GitHub Secrets (wrangler secret put)

This is the ACTUAL working solution:
- GitHub Actions injects ROUTES_CONFIG into wrangler.toml before deploy
- Secrets are set via wrangler-action secrets parameter
- No config overwriting - everything works perfectly

Changes:
- .github/workflows/deploy.yml: inject ROUTES_CONFIG, use secrets for auth/keys
- PRIVATE_CONFIG.md: complete rewrite with correct instructions
- README.md: updated Quick Start with GitHub-based setup
- wrangler.toml: kept clean (no [vars] in repo)
