### PR TITLE
feat: Add tools (function calling) support for Cloudflare AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OpenAI-compatible proxy for multiple AI providers on Cloudflare Workers. Route r
 | Google Gemini | `google` | ✅ | ✅ | Uses official SDK |
 | OpenAI | `openai` | ✅ | ✅ | Uses official SDK |
 | Custom OpenAI-compatible | `openai-compatible` | ✅ | ✅ | NVIDIA AI, etc. |
-| Cloudflare AI Workers | `cloudflare-ai` | ✅ | ❌ | Converts to OpenAI format |
+| Cloudflare AI Workers | `cloudflare-ai` | ✅ | ✅ | Converts to OpenAI format |
 
 ## Quick Start
 


### PR DESCRIPTION
Cloudflare AI now supports tools according to their docs.

Changes:
- src/providers/cloudflare-ai.ts:
  - Added convertTools() to convert OpenAI tools format to CF AI format
  - Added convertToolCalls() to convert CF AI tool_calls to OpenAI format
  - Handle tool_calls in both streaming and non-streaming responses
  - Handle tool role messages (convert to user role for CF AI)
  - Set finish_reason to 'tool_calls' when tools are used

- README.md: Updated Cloudflare AI Workers - Tools column ❌ → ✅

Now all providers support tools/function calling!