### PR TITLE
fix: add minimumReleaseAge=0 to pnpm-workspace.yaml for pnpm 11 compa…

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 0
+
 onlyBuiltDependencies:
   - esbuild
   - protobufjs


### PR DESCRIPTION
…tibility

pnpm 11 (installed via version: latest in CI) reads this setting from pnpm-workspace.yaml, not .npmrc. The .npmrc minimum-release-age=0 only worked with pnpm 10.

https://claude.ai/code/session_01BfwXGsGSX5iJDV6vtmrv76

## 📝 Description
Brief description of changes.

## 🎯 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Checklist
- [ ] Code follows project style
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] Tests added/updated
- [ ] No breaking changes (or documented)
- [ ] Tested locally

## 🧪 Testing
How was this tested?

## 📸 Screenshots (if applicable)
Visual changes.

## 🔗 Related Issues
Closes #issue_number