### PR TITLE
fix: add allowBuilds for pnpm 11 build script approval

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,12 @@ onlyBuiltDependencies:
   - sharp
   - workerd
 
+allowBuilds:
+  esbuild: true
+  protobufjs: true
+  sharp: true
+  workerd: true
+
 overrides:
   "minimatch@9": "^9.0.7"
   "brace-expansion@5": "^5.0.6"


### PR DESCRIPTION
pnpm 11 replaced onlyBuiltDependencies with allowBuilds (map format). Keeping both for pnpm 10 backward compatibility.

https://claude.ai/code/session_01BfwXGsGSX5iJDV6vtmrv76

## 📝 Description
Brief description of changes.

## 🎯 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Checklist
- [ ] Code follows project style
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] Tests added/updated
- [ ] No breaking changes (or documented)
- [ ] Tested locally

## 🧪 Testing
How was this tested?

## 📸 Screenshots (if applicable)
Visual changes.

## 🔗 Related Issues
Closes #issue_number