### PR TITLE
fix: minify ROUTES_CONFIG JSON to stay within Cloudflare 5.1 kB limit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,9 @@ jobs:
         env:
           ROUTES_CONFIG: ${{ vars.ROUTES_CONFIG }}
         run: |
+          # Minify JSON to stay within Cloudflare's 5.1 kB text binding limit
+          MINIFIED_CONFIG=$(echo "$ROUTES_CONFIG" | jq -c .)
+
           # Remove existing [vars] section and everything after it
           sed -i '/^\[vars\]/,$d' wrangler.toml
 
@@ -85,7 +88,7 @@ jobs:
           cat >> wrangler.toml << EOF
 
           [vars]
-          ROUTES_CONFIG = '''${ROUTES_CONFIG}'''
+          ROUTES_CONFIG = '''${MINIFIED_CONFIG}'''
           EOF
 
       - name: Deploy to Cloudflare Workers


### PR DESCRIPTION
Text binding was 5.8 kB due to pretty-printed JSON. jq -c strips whitespace, reducing it well under the 5.1 kB limit.

https://claude.ai/code/session_01BfwXGsGSX5iJDV6vtmrv76

## 📝 Description
Brief description of changes.

## 🎯 Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## ✅ Checklist
- [ ] Code follows project style
- [ ] Self-review completed
- [ ] Documentation updated
- [ ] Tests added/updated
- [ ] No breaking changes (or documented)
- [ ] Tested locally

## 🧪 Testing
How was this tested?

## 📸 Screenshots (if applicable)
Visual changes.

## 🔗 Related Issues
Closes #issue_number